### PR TITLE
更新友情链接：移除 LofiSu 并修复失效地址

### DIFF
--- a/docs/.vitepress/userConfig/friendsInfo.ts
+++ b/docs/.vitepress/userConfig/friendsInfo.ts
@@ -22,7 +22,7 @@ export const friendsInfo: Friend[] = [
     avatar: 'https://avatars.githubusercontent.com/u/108560334?v=4',
     name: 'Ma5hr00m',
     title: '在摇摆与徘徊中前行',
-    link: 'https://blog.kinoko.fun/',
+    link: 'https://kinoko.fun/',
     tag: 'Web Developer',
     color: 'orange'
   },
@@ -46,7 +46,7 @@ export const friendsInfo: Friend[] = [
     avatar: 'https://avatars.githubusercontent.com/u/108183563?v=4',
     name: 'ZzzRemake',
     title: 'Curious and Passionate',
-    link: 'https://zzzremake.github.io/',
+    link: 'https://zzzremake.github.io/site/',
     color: 'indigo'
   },
   {
@@ -85,7 +85,7 @@ export const friendsInfo: Friend[] = [
     avatar: 'https://avatars.githubusercontent.com/u/91458671?v=4',
     name: 'Rui1',
     title: 'Visionary and Driven ',
-    link: 'https://blog.ruinique.cn/',
+    link: 'https://blog.ruinique.com/',
     tag: 'Backend',
     color: 'sky'
   },
@@ -123,7 +123,7 @@ export const friendsInfo: Friend[] = [
   },
   {
     name: 'c0s1ne',
-    link: 'blog.cos02.top',
+    link: 'https://me.cos02.top/',
     title: 'Keep Passion.',
     avatar: 'https://avatars.githubusercontent.com/u/102515482?v=4',
     color: 'pink',

--- a/docs/.vitepress/userConfig/friendsInfo.ts
+++ b/docs/.vitepress/userConfig/friendsInfo.ts
@@ -114,14 +114,6 @@ export const friendsInfo: Friend[] = [
     color: 'orange'
   },
   {
-    avatar: 'https://avatars.githubusercontent.com/u/163713803?v=4',
-    name: 'LofiSu',
-    title: 'Learning is a lifelong journey.Keep going.',
-    link: 'https://www.lofisu.chat/',
-    tag: 'Front-end',
-    color: 'sky'
-  },
-  {
     name: 'Kawhicurry',
     title: "The future is already here.It's just not evenly distributed.",
     link: 'https://kawhicurry.github.io/',

--- a/docs/.vitepress/views/Archive/index.vue
+++ b/docs/.vitepress/views/Archive/index.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
 import { data as posts } from '../../utils/article.data.js'
 import PostCard from './PostCard.vue'
 import Sidebar from './Sidebar.vue'
@@ -65,7 +65,7 @@ const firstHalf = posts.slice(0, halfLength)
 const secondHalf = posts.slice(halfLength)
 
 // 根据当前 page 名称获取 sidebar 数据并构造相应的类别
-const pathname = window.location.pathname
+const pathname = useRoute().path
 const sidebarData = theme.value.sidebar?.[pathname]
 const categories =
   types || sidebarData?.items.map((item: any) => ({ name: item.text, link: item.link }))

--- a/docs/.vitepress/views/BlogArchive.vue
+++ b/docs/.vitepress/views/BlogArchive.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
 import { data as posts } from '../utils/article.data.js'
 import PostCard from './BlogArchivePostCard.vue'
 import Sidebar from './BlogArchiveSidebar.vue'
@@ -54,7 +54,7 @@ const { frontmatter: pageData, theme } = useData()
 const { hero, types, features, flow } = pageData.value
 
 // 根据当前 page 名称获取 sidebar 数据并构造相应的类别
-const pathname = window.location.pathname
+const pathname = useRoute().path
 const sidebarData = theme.value.sidebar?.[pathname]
 const categories =
   types || sidebarData?.items.map((item: any) => ({ name: item.text, link: item.link }))

--- a/docs/.vitepress/views/Home/index.vue
+++ b/docs/.vitepress/views/Home/index.vue
@@ -2,7 +2,9 @@
   <div class="home flex h-screen w-screen items-center justify-center">
     <EmojiBackground />
     <div class="-mt-10 flex w-screen animate-scale-in-center flex-col px-4 sm:-mt-40 sm:w-[626px]">
-      <Vue3Lottie :animationData="lottieData" class="w-full sm:w-[626px]" />
+      <ClientOnly>
+        <Vue3Lottie :animationData="lottieData" class="w-full sm:w-[626px]" />
+      </ClientOnly>
       <div
         class="relative mt-6 flex w-full flex-col items-center rounded-lg bg-white/85 py-6 text-zinc-800 shadow shadow-black/40 backdrop-blur-sm"
       >
@@ -38,9 +40,13 @@
 import { onMounted, ref, onBeforeUnmount } from 'vue'
 import EmojiBackground from '../../components/EmojiBackground/index.vue'
 import { RiGithubLine } from '@remixicon/vue'
-import { useRouter } from 'vitepress'
-import { Vue3Lottie } from 'vue3-lottie'
+import { defineClientComponent, useRouter } from 'vitepress'
 import lottieData from '../../assets/dora.json'
+
+// lottie-web 会在 import 时访问 document，Node 22 下 VitePress SSG 会直接失败
+const Vue3Lottie = defineClientComponent(() =>
+  import('vue3-lottie').then((mod) => mod.Vue3Lottie)
+)
 
 const returnToTopRef = ref<HTMLElement | null>(null)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "devDependencies": {
     "@types/node": "^20.8.8",
     "autoprefixer": "^10.4.15",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
更新友情链接：移除已失效条目，并修正无法跳转的地址。同时包含 Node 22 下 VitePress 构建修复，避免 Vercel 预览失败。

## 友链变更
- 删除 LofiSu 条目
- 修正失效友链：
  - Ma5hr00m：`https://blog.kinoko.fun/` → `https://kinoko.fun/`
  - ZzzRemake：`https://zzzremake.github.io/` → `https://zzzremake.github.io/site/`
  - Rui1：`https://blog.ruinique.cn/` → `https://blog.ruinique.com/`
  - c0s1ne：`blog.cos02.top` → `https://me.cos02.top/`

## 构建修复（Node 22）
- 首页 Lottie 改为客户端加载，避免 SSG 时 `document is not defined`
- 归档页改用 `useRoute()`，避免 `window is not defined`
- `package.json` 锁定 `"engines": { "node": "22.x" }`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de674a42-0ea8-47d5-9892-a97525ad70af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de674a42-0ea8-47d5-9892-a97525ad70af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

