### PR TITLE
修复 Node 22 下 VitePress 构建因 Lottie SSR 失败

### DIFF
--- a/docs/.vitepress/views/Archive/index.vue
+++ b/docs/.vitepress/views/Archive/index.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
 import { data as posts } from '../../utils/article.data.js'
 import PostCard from './PostCard.vue'
 import Sidebar from './Sidebar.vue'
@@ -65,7 +65,7 @@ const firstHalf = posts.slice(0, halfLength)
 const secondHalf = posts.slice(halfLength)
 
 // 根据当前 page 名称获取 sidebar 数据并构造相应的类别
-const pathname = window.location.pathname
+const pathname = useRoute().path
 const sidebarData = theme.value.sidebar?.[pathname]
 const categories =
   types || sidebarData?.items.map((item: any) => ({ name: item.text, link: item.link }))

--- a/docs/.vitepress/views/BlogArchive.vue
+++ b/docs/.vitepress/views/BlogArchive.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
 import { data as posts } from '../utils/article.data.js'
 import PostCard from './BlogArchivePostCard.vue'
 import Sidebar from './BlogArchiveSidebar.vue'
@@ -54,7 +54,7 @@ const { frontmatter: pageData, theme } = useData()
 const { hero, types, features, flow } = pageData.value
 
 // 根据当前 page 名称获取 sidebar 数据并构造相应的类别
-const pathname = window.location.pathname
+const pathname = useRoute().path
 const sidebarData = theme.value.sidebar?.[pathname]
 const categories =
   types || sidebarData?.items.map((item: any) => ({ name: item.text, link: item.link }))

--- a/docs/.vitepress/views/Home/index.vue
+++ b/docs/.vitepress/views/Home/index.vue
@@ -2,7 +2,9 @@
   <div class="home flex h-screen w-screen items-center justify-center">
     <EmojiBackground />
     <div class="-mt-10 flex w-screen animate-scale-in-center flex-col px-4 sm:-mt-40 sm:w-[626px]">
-      <Vue3Lottie :animationData="lottieData" class="w-full sm:w-[626px]" />
+      <ClientOnly>
+        <Vue3Lottie :animationData="lottieData" class="w-full sm:w-[626px]" />
+      </ClientOnly>
       <div
         class="relative mt-6 flex w-full flex-col items-center rounded-lg bg-white/85 py-6 text-zinc-800 shadow shadow-black/40 backdrop-blur-sm"
       >
@@ -38,9 +40,13 @@
 import { onMounted, ref, onBeforeUnmount } from 'vue'
 import EmojiBackground from '../../components/EmojiBackground/index.vue'
 import { RiGithubLine } from '@remixicon/vue'
-import { useRouter } from 'vitepress'
-import { Vue3Lottie } from 'vue3-lottie'
+import { defineClientComponent, useRouter } from 'vitepress'
 import lottieData from '../../assets/dora.json'
+
+// lottie-web 会在 import 时访问 document，Node 22 下 VitePress SSG 会直接失败
+const Vue3Lottie = defineClientComponent(() =>
+  import('vue3-lottie').then((mod) => mod.Vue3Lottie)
+)
 
 const returnToTopRef = ref<HTMLElement | null>(null)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "devDependencies": {
     "@types/node": "^20.8.8",
     "autoprefixer": "^10.4.15",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vercel 不再支持 Node 18 后，项目切到 Node 22，构建会在预渲染时失败：

```
ReferenceError: document is not defined
    at createTag (.../lottie-web/build/player/lottie.js)
```

原因：首页静态引入了 `vue3-lottie`，它依赖的 `lottie-web` 在模块加载时就会访问浏览器 `document`。VitePress 生产构建会在 Node 里做 SSG，这条路径在 Node 22 下会直接炸掉。

另外归档页在 `setup` 里读了 `window.location`，预渲染时会再报 `window is not defined`。

## 变更
- 首页 Lottie 改为 `defineClientComponent` + `ClientOnly`，只在浏览器里加载
- 归档页改用 VitePress `useRoute().path`，不再访问 `window`
- `package.json` 增加 `"engines": { "node": "22.x" }`，与 Vercel Node 22 对齐

## 验证
本地 Node 22.14.0 下 `pnpm run docs:build` 已通过（预渲染阶段不再出现 document/window 报错）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de674a42-0ea8-47d5-9892-a97525ad70af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de674a42-0ea8-47d5-9892-a97525ad70af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

